### PR TITLE
Adjust fixture display and knockout stage handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,9 +161,9 @@
                         <h4 class="font-semibold text-blue-900 mb-2">How to Play:</h4>
                         <ul class="text-sm text-blue-800 space-y-1">
                             <li>• Pick one team per round from the available teams</li>
-                            <li>• If your team wins or draws, you advance to the next round</li>
-                            <li>• If your team loses, you're eliminated from the game</li>
-                            <li>• Each team can only be used once per player</li>
+                            <li>• If your team wins, you advance to the next round</li>
+                            <li>• If your team loses or draws, you're eliminated from the game</li>
+                            <li>• After Round 16, teams will reset again</li>
                             <li>• Last player(s) remaining win the championship!</li>
                         </ul>
                     </div>
@@ -895,17 +895,17 @@
                 const userPickedTeam = userPick;
                 const roundFixtures = gameData.fixtures.filter(f => f.round === round);
 
-                // Check if user's team won or drew
+                // Check if user's team won (only wins advance, draws = elimination)
                 let userSurvived = false;
                 for (const fixture of roundFixtures) {
                     if (fixture.home === userPickedTeam || fixture.away === userPickedTeam) {
                         if (fixture.completed) {
-                            if (fixture.home === userPickedTeam && fixture.homeScore >= fixture.awayScore) {
-                                userSurvived = true; // Win or draw
-                            } else if (fixture.away === userPickedTeam && fixture.awayScore >= fixture.homeScore) {
-                                userSurvived = true; // Win or draw
+                            if (fixture.home === userPickedTeam && fixture.homeScore > fixture.awayScore) {
+                                userSurvived = true; // Win
+                            } else if (fixture.away === userPickedTeam && fixture.awayScore > fixture.homeScore) {
+                                userSurvived = true; // Win
                             } else {
-                                userSurvived = false; // Loss
+                                userSurvived = false; // Loss or draw
                             }
                         }
                         break;
@@ -957,8 +957,10 @@
                 // Check if user is eliminated
                 const userEliminated = eliminatedUsers[currentUser.id];
 
-                // In knockout rounds, teams are only available if they won their previous match
-                let teamAvailable = !alreadyPicked && !userEliminated;
+                // Check if team was already picked by this user in previous rounds
+                // Teams reset after round 16, so allow reuse after that
+                const teamUsedBefore = Object.values(userPicks).includes(team.id) && gameData.currentRound <= 16;
+                let teamAvailable = !alreadyPicked && !userEliminated && !teamUsedBefore;
 
                 if (gameData.seasonPhase === 'knockout') {
                     // For knockout rounds, teams are only available if they won the previous round
@@ -1040,6 +1042,13 @@
             // Allow re-selecting already picked team (to change pick), but not eliminated teams or users
             if (userEliminated) {
                 showNotification('You have been eliminated and cannot make picks', 'warning');
+                return;
+            }
+
+            // Check if team was already picked in previous rounds (teams reset after round 16)
+            const teamUsedBefore = Object.values(userPicks).includes(teamId) && gameData.currentRound <= 16;
+            if (teamUsedBefore && !alreadyPicked) {
+                showNotification('This team was already used in a previous round', 'warning');
                 return;
             }
 
@@ -1396,16 +1405,16 @@
             const roundFixtures = gameData.fixtures.filter(f => f.round === round);
             const userPickedTeam = userPick;
 
-            // Check if user's team won or drew
+            // Check if user's team won (only wins advance, draws = elimination)
             for (const fixture of roundFixtures) {
                 if (fixture.home === userPickedTeam || fixture.away === userPickedTeam) {
                     if (fixture.completed) {
-                        if (fixture.home === userPickedTeam && fixture.homeScore >= fixture.awayScore) {
-                            return true; // Win or draw
-                        } else if (fixture.away === userPickedTeam && fixture.awayScore >= fixture.homeScore) {
-                            return true; // Win or draw
+                        if (fixture.home === userPickedTeam && fixture.homeScore > fixture.awayScore) {
+                            return true; // Win
+                        } else if (fixture.away === userPickedTeam && fixture.awayScore > fixture.homeScore) {
+                            return true; // Win
                         } else {
-                            return false; // Loss
+                            return false; // Loss or draw
                         }
                     } else {
                         // Fixture not completed yet, assume user survives for now

--- a/index.html
+++ b/index.html
@@ -91,6 +91,69 @@
                     </div>
                 </div>
 
+                <!-- Knockout Fixtures Admin Panel -->
+                <div class="bg-orange-50 rounded-lg p-4 mb-6">
+                    <h4 class="text-lg font-semibold text-orange-800 mb-3">Knockout Fixtures Management</h4>
+                    <p class="text-sm text-orange-700 mb-3">Add and manage knockout round fixtures (Rounds 19-21)</p>
+
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-orange-800 mb-2">Select Round to Manage:</label>
+                        <select id="knockoutRoundSelector" class="w-full px-3 py-2 border border-orange-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500">
+                            <option value="19">Quarter Finals (Round 19)</option>
+                            <option value="20">Semi Finals (Round 20)</option>
+                            <option value="21">Final (Round 21)</option>
+                        </select>
+                    </div>
+
+                    <div class="bg-white rounded-lg p-4 mb-4">
+                        <h5 class="font-semibold text-gray-800 mb-3">Add/Edit Fixture</h5>
+                        <div class="grid grid-cols-2 gap-4 mb-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Home Team</label>
+                                <select id="knockoutHomeTeam" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500">
+                                    <!-- Teams will be populated by JavaScript -->
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Away Team</label>
+                                <select id="knockoutAwayTeam" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500">
+                                    <!-- Teams will be populated by JavaScript -->
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="grid grid-cols-2 gap-4 mb-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Date</label>
+                                <input type="date" id="knockoutDate" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Time</label>
+                                <input type="time" id="knockoutTime" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500">
+                            </div>
+                        </div>
+
+                        <div class="flex gap-2">
+                            <button id="addKnockoutFixtureBtn" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700 font-medium">
+                                Add Fixture
+                            </button>
+                            <button id="updateKnockoutFixtureBtn" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 font-medium hidden">
+                                Update Fixture
+                            </button>
+                            <button id="clearKnockoutFormBtn" class="bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700 font-medium">
+                                Clear Form
+                            </button>
+                        </div>
+                    </div>
+
+                    <div>
+                        <h5 class="font-semibold text-gray-800 mb-3">Current Knockout Fixtures</h5>
+                        <div id="knockoutFixturesList" class="space-y-2">
+                            <!-- Knockout fixtures will be populated by JavaScript -->
+                        </div>
+                    </div>
+                </div>
+
                 <div class="bg-white rounded-xl card-shadow p-6 mb-6">
                     <h3 class="text-xl font-semibold text-gray-800 mb-4">Your Fantasy League</h3>
 
@@ -250,6 +313,12 @@
             document.getElementById('resetGameBtn').addEventListener('click', resetGameData);
             document.getElementById('toggleAdminBtn').addEventListener('click', toggleAdminPanel);
             document.getElementById('finalizeAllBtn').addEventListener('click', finalizeAllPendingMatches);
+
+            // Knockout admin controls
+            document.getElementById('knockoutRoundSelector').addEventListener('change', updateKnockoutFixturesList);
+            document.getElementById('addKnockoutFixtureBtn').addEventListener('click', addKnockoutFixture);
+            document.getElementById('updateKnockoutFixtureBtn').addEventListener('click', updateKnockoutFixture);
+            document.getElementById('clearKnockoutFormBtn').addEventListener('click', clearKnockoutForm);
         }
 
         // Switch between login and register modes
@@ -665,18 +734,24 @@
             const roundSelector = document.getElementById('roundSelector');
             roundSelector.innerHTML = '';
 
-            // Get all unique rounds from fixtures
-            const rounds = [...new Set(gameData.fixtures.map(f => f.round))].sort((a, b) => a - b);
+            // Get all unique rounds from fixtures (limit to rounds 1-18 for "All Fixtures" view)
+            const allRounds = [...new Set(gameData.fixtures.map(f => f.round))].sort((a, b) => a - b);
+            const rounds = allRounds.filter(round => round <= 18); // Only show rounds 1-18
 
             rounds.forEach(round => {
                 const option = document.createElement('option');
                 option.value = round;
                 option.textContent = getRoundName(round);
-                if (round === gameData.currentRound) {
+                if (round === gameData.currentRound && gameData.currentRound <= 18) {
                     option.selected = true;
                 }
                 roundSelector.appendChild(option);
             });
+
+            // If current round is beyond 18, select the last available round (18)
+            if (gameData.currentRound > 18 && rounds.length > 0) {
+                roundSelector.value = Math.max(...rounds);
+            }
         }
 
         // Update all fixtures view for selected round
@@ -703,38 +778,7 @@
                 fixtureDiv.className = `bg-gray-50 rounded-lg p-4 ${fixture.completed ? 'bg-green-50' : ''}`;
 
                 let scoreDisplay = '';
-                let winnerButtons = '';
-                let finalizeButton = '';
-
-                if (!fixture.completed) {
-                    // Show winner selection buttons
-                    winnerButtons = `
-                        <div class="mt-3 flex gap-2">
-                            <button onclick="setWinner('${fixture.home}', '${fixture.away}', ${selectedRound})"
-                                    class="bg-green-500 text-white px-3 py-1 rounded text-sm hover:bg-green-600">
-                                ${homeTeam.name} Win
-                            </button>
-                            <button onclick="setDraw('${fixture.home}', '${fixture.away}', ${selectedRound})"
-                                    class="bg-yellow-500 text-white px-3 py-1 rounded text-sm hover:bg-yellow-600">
-                                Draw
-                            </button>
-                            <button onclick="setWinner('${fixture.away}', '${fixture.home}', ${selectedRound})"
-                                    class="bg-blue-500 text-white px-3 py-1 rounded text-sm hover:bg-blue-600">
-                                ${awayTeam.name} Win
-                            </button>
-                        </div>
-                    `;
-
-                    finalizeButton = `
-                        <div class="mt-3">
-                            <button onclick="finalizeMatch('${fixture.home}', '${fixture.away}', ${selectedRound})"
-                                    class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 font-medium">
-                                Finalize Match
-                            </button>
-                        </div>
-                    `;
-                } else {
-                    // Show final result
+                if (fixture.completed && fixture.homeScore !== null && fixture.awayScore !== null) {
                     scoreDisplay = `<span class="text-lg font-bold text-green-600">(${fixture.homeScore} - ${fixture.awayScore})</span>`;
                 }
 
@@ -747,6 +791,8 @@
                     statusText = '<span class="text-blue-600 text-sm">Today</span>';
                 } else if (dateTimeInfo.isTomorrow) {
                     statusText = '<span class="text-orange-600 text-sm">Tomorrow</span>';
+                } else {
+                    statusText = '<span class="text-gray-600 text-sm">Upcoming</span>';
                 }
 
                 fixtureDiv.innerHTML = `
@@ -758,8 +804,6 @@
                             </div>
                             <div class="text-sm text-gray-600 mb-2">${dateTimeInfo.formatted}</div>
                             ${scoreDisplay}
-                            ${winnerButtons}
-                            ${finalizeButton}
                         </div>
                     </div>
                 `;
@@ -1562,6 +1606,280 @@
                 }, 300);
             }, 5000);
         }
+
+        // Initialize knockout admin panel
+        function initializeKnockoutAdminPanel() {
+            populateKnockoutTeamDropdowns();
+            updateKnockoutFixturesList();
+        }
+
+        // Populate team dropdowns for knockout admin
+        function populateKnockoutTeamDropdowns() {
+            const homeTeamSelect = document.getElementById('knockoutHomeTeam');
+            const awayTeamSelect = document.getElementById('knockoutAwayTeam');
+
+            homeTeamSelect.innerHTML = '';
+            awayTeamSelect.innerHTML = '';
+
+            gameData.teams.forEach(team => {
+                const homeOption = document.createElement('option');
+                homeOption.value = team.id;
+                homeOption.textContent = team.name;
+                homeTeamSelect.appendChild(homeOption);
+
+                const awayOption = document.createElement('option');
+                awayOption.value = team.id;
+                awayOption.textContent = team.name;
+                awayTeamSelect.appendChild(awayOption);
+            });
+        }
+
+        // Update knockout fixtures list display
+        function updateKnockoutFixturesList() {
+            const roundSelector = document.getElementById('knockoutRoundSelector');
+            const selectedRound = parseInt(roundSelector.value);
+
+            const knockoutFixturesList = document.getElementById('knockoutFixturesList');
+            knockoutFixturesList.innerHTML = '';
+
+            const roundFixtures = gameData.fixtures.filter(f => f.round === selectedRound);
+
+            if (roundFixtures.length === 0) {
+                knockoutFixturesList.innerHTML = '<p class="text-gray-600">No fixtures added for this round yet.</p>';
+                return;
+            }
+
+            roundFixtures.forEach((fixture, index) => {
+                const homeTeam = gameData.teams.find(t => t.id === fixture.home);
+                const awayTeam = gameData.teams.find(t => t.id === fixture.away);
+                const dateTimeInfo = formatDateTime(fixture.date, fixture.time);
+
+                const fixtureDiv = document.createElement('div');
+                fixtureDiv.className = `bg-gray-50 rounded-lg p-3 ${fixture.completed ? 'bg-green-50' : ''}`;
+
+                let scoreDisplay = '';
+                if (fixture.completed && fixture.homeScore !== null && fixture.awayScore !== null) {
+                    scoreDisplay = `<span class="text-lg font-bold text-green-600">(${fixture.homeScore} - ${fixture.awayScore})</span>`;
+                }
+
+                let statusText = '';
+                if (fixture.completed) {
+                    statusText = '<span class="text-green-600 text-sm">✓ Completed</span>';
+                } else {
+                    statusText = '<span class="text-gray-600 text-sm">Pending</span>';
+                }
+
+                fixtureDiv.innerHTML = `
+                    <div class="flex justify-between items-center">
+                        <div class="flex-1">
+                            <div class="font-semibold">${homeTeam.name} vs ${awayTeam.name}</div>
+                            <div class="text-sm text-gray-600">${dateTimeInfo.formatted}</div>
+                            ${scoreDisplay}
+                            ${statusText}
+                        </div>
+                        <div class="flex gap-2">
+                            <button onclick="editKnockoutFixture(${index})"
+                                    class="bg-blue-500 text-white px-3 py-1 rounded text-sm hover:bg-blue-600">
+                                Edit
+                            </button>
+                            <button onclick="deleteKnockoutFixture(${selectedRound}, '${fixture.home}', '${fixture.away}')"
+                                    class="bg-red-500 text-white px-3 py-1 rounded text-sm hover:bg-red-600">
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                `;
+
+                knockoutFixturesList.appendChild(fixtureDiv);
+            });
+        }
+
+        // Add new knockout fixture
+        function addKnockoutFixture() {
+            const round = parseInt(document.getElementById('knockoutRoundSelector').value);
+            const homeTeam = document.getElementById('knockoutHomeTeam').value;
+            const awayTeam = document.getElementById('knockoutAwayTeam').value;
+            const date = document.getElementById('knockoutDate').value;
+            const time = document.getElementById('knockoutTime').value;
+
+            if (!homeTeam || !awayTeam || !date || !time) {
+                showNotification('Please fill in all fields', 'error');
+                return;
+            }
+
+            if (homeTeam === awayTeam) {
+                showNotification('Home and away teams must be different', 'error');
+                return;
+            }
+
+            // Check if fixture already exists
+            const existingFixture = gameData.fixtures.find(f =>
+                f.round === round &&
+                ((f.home === homeTeam && f.away === awayTeam) || (f.home === awayTeam && f.away === homeTeam))
+            );
+
+            if (existingFixture) {
+                showNotification('This fixture already exists for this round', 'error');
+                return;
+            }
+
+            const newFixture = {
+                round: round,
+                home: homeTeam,
+                away: awayTeam,
+                homeScore: null,
+                awayScore: null,
+                completed: false,
+                date: date,
+                time: time
+            };
+
+            gameData.fixtures.push(newFixture);
+            localStorage.setItem('gameData', JSON.stringify(gameData));
+
+            showNotification('Knockout fixture added successfully!', 'success');
+            clearKnockoutForm();
+            updateKnockoutFixturesList();
+        }
+
+        // Edit knockout fixture
+        function editKnockoutFixture(index) {
+            const round = parseInt(document.getElementById('knockoutRoundSelector').value);
+            const roundFixtures = gameData.fixtures.filter(f => f.round === round);
+
+            if (index >= roundFixtures.length) {
+                showNotification('Fixture not found', 'error');
+                return;
+            }
+
+            const fixture = roundFixtures[index];
+
+            // Populate form with fixture data
+            document.getElementById('knockoutHomeTeam').value = fixture.home;
+            document.getElementById('knockoutAwayTeam').value = fixture.away;
+            document.getElementById('knockoutDate').value = fixture.date;
+            document.getElementById('knockoutTime').value = fixture.time;
+
+            // Show update button, hide add button
+            document.getElementById('addKnockoutFixtureBtn').classList.add('hidden');
+            document.getElementById('updateKnockoutFixtureBtn').classList.remove('hidden');
+
+            // Store the original fixture data for update
+            window.editingFixture = {
+                round: round,
+                home: fixture.home,
+                away: fixture.away
+            };
+
+            showNotification('Fixture loaded for editing', 'info');
+        }
+
+        // Update knockout fixture
+        function updateKnockoutFixture() {
+            const round = parseInt(document.getElementById('knockoutRoundSelector').value);
+            const homeTeam = document.getElementById('knockoutHomeTeam').value;
+            const awayTeam = document.getElementById('knockoutAwayTeam').value;
+            const date = document.getElementById('knockoutDate').value;
+            const time = document.getElementById('knockoutTime').value;
+
+            if (!homeTeam || !awayTeam || !date || !time) {
+                showNotification('Please fill in all fields', 'error');
+                return;
+            }
+
+            if (homeTeam === awayTeam) {
+                showNotification('Home and away teams must be different', 'error');
+                return;
+            }
+
+            // Find the fixture to update
+            const fixtureIndex = gameData.fixtures.findIndex(f =>
+                f.round === window.editingFixture.round &&
+                f.home === window.editingFixture.home &&
+                f.away === window.editingFixture.away
+            );
+
+            if (fixtureIndex === -1) {
+                showNotification('Original fixture not found', 'error');
+                return;
+            }
+
+            // Check if another fixture with same teams already exists (excluding current)
+            const existingFixture = gameData.fixtures.find(f =>
+                f.round === round &&
+                ((f.home === homeTeam && f.away === awayTeam) || (f.home === awayTeam && f.away === homeTeam)) &&
+                !(f.home === window.editingFixture.home && f.away === window.editingFixture.away)
+            );
+
+            if (existingFixture) {
+                showNotification('This fixture already exists for this round', 'error');
+                return;
+            }
+
+            // Update the fixture
+            gameData.fixtures[fixtureIndex] = {
+                round: round,
+                home: homeTeam,
+                away: awayTeam,
+                homeScore: gameData.fixtures[fixtureIndex].homeScore,
+                awayScore: gameData.fixtures[fixtureIndex].awayScore,
+                completed: gameData.fixtures[fixtureIndex].completed,
+                date: date,
+                time: time
+            };
+
+            localStorage.setItem('gameData', JSON.stringify(gameData));
+
+            showNotification('Knockout fixture updated successfully!', 'success');
+            clearKnockoutForm();
+            updateKnockoutFixturesList();
+        }
+
+        // Delete knockout fixture
+        function deleteKnockoutFixture(round, home, away) {
+            if (!confirm('Are you sure you want to delete this fixture?')) {
+                return;
+            }
+
+            const fixtureIndex = gameData.fixtures.findIndex(f =>
+                f.round === round &&
+                f.home === home &&
+                f.away === away
+            );
+
+            if (fixtureIndex === -1) {
+                showNotification('Fixture not found', 'error');
+                return;
+            }
+
+            gameData.fixtures.splice(fixtureIndex, 1);
+            localStorage.setItem('gameData', JSON.stringify(gameData));
+
+            showNotification('Knockout fixture deleted successfully!', 'success');
+            updateKnockoutFixturesList();
+        }
+
+        // Clear knockout form
+        function clearKnockoutForm() {
+            document.getElementById('knockoutHomeTeam').value = '';
+            document.getElementById('knockoutAwayTeam').value = '';
+            document.getElementById('knockoutDate').value = '';
+            document.getElementById('knockoutTime').value = '';
+
+            // Show add button, hide update button
+            document.getElementById('addKnockoutFixtureBtn').classList.remove('hidden');
+            document.getElementById('updateKnockoutFixtureBtn').classList.add('hidden');
+
+            // Clear editing fixture reference
+            window.editingFixture = null;
+        }
+
+        // Initialize knockout admin panel when page loads
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(() => {
+                initializeKnockoutAdminPanel();
+            }, 100);
+        });
 
         console.log('Simple URC Fantasy League app loaded');
     </script>

--- a/index.html
+++ b/index.html
@@ -986,22 +986,26 @@
 
                 let statusText = '';
                 let statusClass = '';
+                let cardClass = '';
 
                 if (alreadyPicked) {
-                    statusText = 'Already Picked';
-                    statusClass = 'text-red-600';
-                    teamCard.className = 'bg-red-100 rounded-lg p-3 text-center cursor-not-allowed opacity-60';
+                    statusText = 'Your Pick';
+                    statusClass = 'text-green-600';
+                    cardClass = 'bg-green-100 border-2 border-green-500 rounded-lg p-3 text-center cursor-pointer hover:bg-green-200 transition-colors team-card';
                 } else if (userEliminated) {
                     statusText = 'Eliminated';
                     statusClass = 'text-red-600';
-                    teamCard.className = 'bg-red-100 rounded-lg p-3 text-center cursor-not-allowed opacity-60';
+                    cardClass = 'bg-red-100 rounded-lg p-3 text-center cursor-not-allowed opacity-60';
                 } else if (gameData.seasonPhase === 'knockout' && !teamAvailable) {
                     statusText = 'Eliminated';
                     statusClass = 'text-red-600';
-                    teamCard.className = 'bg-red-100 rounded-lg p-3 text-center cursor-not-allowed opacity-60';
+                    cardClass = 'bg-red-100 rounded-lg p-3 text-center cursor-not-allowed opacity-60';
                 } else {
-                    teamCard.className = 'bg-gray-100 rounded-lg p-3 text-center cursor-pointer hover:bg-gray-200 transition-colors team-card';
+                    cardClass = 'bg-gray-100 rounded-lg p-3 text-center cursor-pointer hover:bg-gray-200 transition-colors team-card';
                 }
+
+                // Apply the card class
+                teamCard.className = cardClass;
 
                 // Check if this team is currently selected (for visual feedback)
                 const isSelected = selectedTeam === team.id;
@@ -1027,19 +1031,20 @@
         }
 
         function selectTeam(teamId) {
-            // Check if team is available (not already picked, user not eliminated, etc.)
+            // Check if team is available (user not eliminated, etc.)
             const userPicks = gameData.userPicks[currentUser.id] || {};
             const eliminatedUsers = gameData.eliminatedUsers || {};
             const alreadyPicked = userPicks[gameData.currentRound] === teamId;
             const userEliminated = eliminatedUsers[currentUser.id];
 
-            if (alreadyPicked || userEliminated) {
-                showNotification('This team is not available for selection', 'warning');
+            // Allow re-selecting already picked team (to change pick), but not eliminated teams or users
+            if (userEliminated) {
+                showNotification('You have been eliminated and cannot make picks', 'warning');
                 return;
             }
 
-            // In knockout rounds, check if team won previous round
-            if (gameData.seasonPhase === 'knockout') {
+            // In knockout rounds, check if team won previous round (but allow if already picked)
+            if (gameData.seasonPhase === 'knockout' && !alreadyPicked) {
                 const previousRound = gameData.currentRound - 1;
                 const previousRoundFixtures = gameData.fixtures.filter(f => f.round === previousRound);
                 let teamWonPrevious = true;
@@ -1088,6 +1093,10 @@
             }
 
             try {
+                // Check if this is a new pick or changing existing pick
+                const userPicks = gameData.userPicks[currentUser.id] || {};
+                const previousPick = userPicks[gameData.currentRound];
+
                 // Store user's pick
                 if (!gameData.userPicks[currentUser.id]) {
                     gameData.userPicks[currentUser.id] = {};
@@ -1096,7 +1105,14 @@
                 gameData.userPicks[currentUser.id][gameData.currentRound] = selectedTeam;
                 localStorage.setItem('gameData', JSON.stringify(gameData));
 
-                showNotification(`Pick submitted: ${gameData.teams.find(t => t.id === selectedTeam).name}`, 'success');
+                const teamName = gameData.teams.find(t => t.id === selectedTeam).name;
+
+                if (previousPick && previousPick !== selectedTeam) {
+                    const previousTeamName = gameData.teams.find(t => t.id === previousPick).name;
+                    showNotification(`Pick changed from ${previousTeamName} to ${teamName}`, 'success');
+                } else {
+                    showNotification(`Pick submitted: ${teamName}`, 'success');
+                }
 
                 // Keep the green styling after successful submission
                 const selectedCard = document.querySelector(`[data-team-id="${selectedTeam}"]`);

--- a/index.html
+++ b/index.html
@@ -1030,7 +1030,7 @@
             // Check if team is available (not already picked, user not eliminated, etc.)
             const userPicks = gameData.userPicks[currentUser.id] || {};
             const eliminatedUsers = gameData.eliminatedUsers || {};
-            const alreadyPicked = Object.values(userPicks).includes(teamId);
+            const alreadyPicked = userPicks[gameData.currentRound] === teamId;
             const userEliminated = eliminatedUsers[currentUser.id];
 
             if (alreadyPicked || userEliminated) {


### PR DESCRIPTION
Separate knockout round management for admins and make the 'All Fixtures' view read-only for regular season matches (rounds 1-18).

The 'All Fixtures' tab previously allowed 'make pick' functionality and admin controls, which was not the intended behavior for a general overview. This PR ensures it is a read-only display for regular season rounds (1-18). Furthermore, it introduces a dedicated admin panel for manually adding and managing knockout stage fixtures (rounds 19-21), as these matches require specific team, date, and time inputs from the administrator.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e0f741d-58b0-4d3c-86e6-a06460eac6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e0f741d-58b0-4d3c-86e6-a06460eac6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

